### PR TITLE
ci: add macOS release pipeline and Xcode Cloud version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       APP_NAME: Cassette
       SCHEME: Cassette
       PROJECT: Cassette.xcodeproj
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_TEAM_ID: LK2358MPL8
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Pin Xcode
-        run: sudo xcode-select -s /Applications/Xcode_27.app   # project requires Xcode 27 (iOS 26 / macOS 26 SDK); match the macos-26 image's installed path
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
 
       - name: Derive version from tag
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  macos-release:
+    runs-on: macos-26
+    env:
+      APP_NAME: Cassette
+      SCHEME: Cassette
+      PROJECT: Cassette.xcodeproj
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pin Xcode
+        run: sudo xcode-select -s /Applications/Xcode_27.app   # project requires Xcode 27 (iOS 26 / macOS 26 SDK); match the macos-26 image's installed path
+
+      - name: Derive version from tag
+        id: version
+        run: |
+          if [ -n "${GITHUB_REF_NAME:-}" ] && [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="0.0.0-dev"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building version $VERSION"
+
+      - name: Import Developer ID certificate into a temp keychain
+        env:
+          CERT_P12_BASE64: ${{ secrets.DEVELOPER_ID_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -P "$CERT_PASSWORD" \
+            -k "$KEYCHAIN" -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+
+      - name: Archive (macOS, manual Developer ID signing)
+        run: |
+          xcodebuild \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Release \
+            -destination 'generic/platform=macOS' \
+            -archivePath "$RUNNER_TEMP/$APP_NAME.xcarchive" \
+            MARKETING_VERSION="${{ steps.version.outputs.version }}" \
+            CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+            archive
+
+      - name: Export Developer ID app
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/$APP_NAME.xcarchive" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -exportOptionsPlist ExportOptions-DeveloperID.plist
+
+      - name: Write App Store Connect API key
+        env:
+          AC_API_KEY_P8_BASE64: ${{ secrets.AC_API_KEY_P8_BASE64 }}
+        run: echo "$AC_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+
+      - name: Notarize + staple the .app
+        env:
+          AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+          AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+        run: |
+          APP="$RUNNER_TEMP/export/$APP_NAME.app"
+          ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/$APP_NAME.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/$APP_NAME.zip" \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$AC_API_KEY_ID" \
+            --issuer "$AC_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$APP"
+
+      - name: Create .dmg
+        run: |
+          brew install create-dmg
+          DMG="$RUNNER_TEMP/$APP_NAME-${{ steps.version.outputs.version }}.dmg"
+          create-dmg \
+            --volname "$APP_NAME" \
+            --window-size 540 380 \
+            --icon-size 120 \
+            --icon "$APP_NAME.app" 150 190 \
+            --app-drop-link 390 190 \
+            --hide-extension "$APP_NAME.app" \
+            "$DMG" \
+            "$RUNNER_TEMP/export/$APP_NAME.app"
+
+      - name: Notarize + staple the .dmg
+        env:
+          AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+          AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+        run: |
+          DMG="$RUNNER_TEMP/$APP_NAME-${{ steps.version.outputs.version }}.dmg"
+          xcrun notarytool submit "$DMG" \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$AC_API_KEY_ID" \
+            --issuer "$AC_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$DMG"
+
+      - name: Publish GitHub Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ runner.temp }}/${{ env.APP_NAME }}-${{ steps.version.outputs.version }}.dmg
+          generate_release_notes: true
+
+      - name: Bump Homebrew cask
+        if: github.ref_type == 'tag'
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DMG="$RUNNER_TEMP/$APP_NAME-$VERSION.dmg"
+          SHA="$(shasum -a 256 "$DMG" | awk '{print $1}')"
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/MathieuDubart/homebrew-cassette.git" tap
+          cd tap
+          CASK="Casks/cassette.rb"
+          /usr/bin/sed -i '' -E "s/^  version \".*\"/  version \"$VERSION\"/" "$CASK"
+          /usr/bin/sed -i '' -E "s/^  sha256 \".*\"/  sha256 \"$SHA\"/" "$CASK"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$CASK"
+          git commit -m "chore(cask): update cassette to $VERSION"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,16 @@ jobs:
           CASK="Casks/cassette.rb"
           /usr/bin/sed -i '' -E "s/^  version \".*\"/  version \"$VERSION\"/" "$CASK"
           /usr/bin/sed -i '' -E "s/^  sha256 \".*\"/  sha256 \"$SHA\"/" "$CASK"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$CASK"
-          git commit -m "chore(cask): update cassette to $VERSION"
-          git push
+          if git diff --quiet -- "$CASK"; then
+            echo "Cask already at $VERSION — nothing to bump."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add "$CASK"
+            git commit -m "chore(cask): update cassette to $VERSION"
+            git push
+          fi
+
+      - name: Clean up sensitive files on runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/AuthKey.p8" "$RUNNER_TEMP/cert.p12"

--- a/Cassette.xcodeproj/project.pbxproj
+++ b/Cassette.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Cassette/Cassette-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = LK2358MPL8;
 				ENABLE_APP_SANDBOX = YES;
@@ -634,6 +635,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Cassette/Cassette-macOS.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				VERSIONING_SYSTEM = "apple-generic";
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = LK2358MPL8;
 				ENABLE_APP_SANDBOX = YES;

--- a/ExportOptions-DeveloperID.plist
+++ b/ExportOptions-DeveloperID.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>developer-id</string>
+    <key>teamID</key>
+    <string>LK2358MPL8</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Developer ID Application</string>
+</dict>
+</plist>

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Xcode Cloud runs this before building (must live in ci_scripts/ at repo root, executable).
+# Syncs the TestFlight build's marketing version with the git tag.
+
+set -e
+
+if [ -n "$CI_TAG" ]; then
+  VERSION="${CI_TAG#v}"
+  echo "Setting marketing version to $VERSION from tag $CI_TAG"
+  cd "$CI_PRIMARY_REPOSITORY_PATH"
+  agvtool new-marketing-version "$VERSION"
+else
+  echo "No CI_TAG set — leaving marketing version untouched."
+fi

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -44,7 +44,6 @@ Set these in the repo settings (Settings → Secrets and variables → Actions):
 | `AC_API_KEY_P8_BASE64` | Base64 of the App Store Connect API key (`.p8`), used for notarization |
 | `AC_API_KEY_ID` | App Store Connect API key ID |
 | `AC_API_ISSUER_ID` | App Store Connect API issuer ID |
-| `APPLE_TEAM_ID` | Apple Developer Team ID (`LK2358MPL8`) |
 | `HOMEBREW_TAP_TOKEN` | PAT with write access to `MathieuDubart/homebrew-cassette` |
 
 `ExportOptions-DeveloperID.plist` is committed (Team ID is not a secret). No

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,89 @@
+# Releasing Cassette
+
+Cassette ships through two independent channels, both triggered by pushing a
+`v*` git tag (e.g. `v1.9.0`).
+
+| Channel | Target | Driver | Artifact |
+| --- | --- | --- | --- |
+| iOS | TestFlight → App Store | **Xcode Cloud** (configured in App Store Connect) | `.ipa` uploaded to TestFlight |
+| macOS | Direct download / Homebrew | **GitHub Actions** (`.github/workflows/release.yml`) | notarized `.dmg` on the GitHub Release, cask bumped in the tap |
+
+The two channels do not depend on each other; a tag push fans out to both.
+
+## Release flow
+
+1. Bump the version locally if you want a specific marketing version, or let the
+   pipelines derive it from the tag (both read `v<version>`).
+2. Tag and push:
+   ```sh
+   git tag v1.9.0
+   git push origin v1.9.0
+   ```
+3. **macOS (GitHub Actions):** archives the `Cassette` scheme for macOS with
+   manual Developer ID signing, exports via `ExportOptions-DeveloperID.plist`,
+   notarizes + staples the `.app` and `.dmg`, publishes a GitHub Release with the
+   `.dmg`, then bumps `Casks/cassette.rb` in the tap repo.
+4. **iOS (Xcode Cloud):** runs `ci_scripts/ci_pre_xcodebuild.sh` (syncs the
+   marketing version from `$CI_TAG` via `agvtool`), builds, and uploads to
+   TestFlight.
+
+The version is derived from the tag name with the leading `v` stripped. On a
+manual `workflow_dispatch` run (no tag), the macOS job builds `0.0.0-dev` and
+**does not** publish a Release or bump the cask — both steps are guarded by
+`if: github.ref_type == 'tag'`.
+
+## Required GitHub secrets
+
+Set these in the repo settings (Settings → Secrets and variables → Actions):
+
+| Secret | Purpose |
+| --- | --- |
+| `DEVELOPER_ID_CERT_P12_BASE64` | Base64 of the Developer ID Application cert exported as `.p12` (with private key) |
+| `DEVELOPER_ID_CERT_PASSWORD` | Password protecting that `.p12` |
+| `KEYCHAIN_PASSWORD` | Arbitrary password for the temporary CI keychain |
+| `AC_API_KEY_P8_BASE64` | Base64 of the App Store Connect API key (`.p8`), used for notarization |
+| `AC_API_KEY_ID` | App Store Connect API key ID |
+| `AC_API_ISSUER_ID` | App Store Connect API issuer ID |
+| `APPLE_TEAM_ID` | Apple Developer Team ID (`LK2358MPL8`) |
+| `HOMEBREW_TAP_TOKEN` | PAT with write access to `MathieuDubart/homebrew-cassette` |
+
+`ExportOptions-DeveloperID.plist` is committed (Team ID is not a secret). No
+certificate, key, or password is stored in this repo.
+
+## One-time human setup
+
+1. **Developer ID cert:** create a *Developer ID Application* certificate on the
+   developer portal, then export it **with its private key** as `.p12` from
+   Keychain Access. Base64-encode it (`base64 -i cert.p12 | pbcopy`) into
+   `DEVELOPER_ID_CERT_P12_BASE64`.
+2. **App Store Connect API key:** create an API key, download the `.p8`, and
+   base64-encode it into `AC_API_KEY_P8_BASE64`; record its key ID and issuer ID.
+3. **Add the GitHub secrets** listed above.
+4. **Homebrew tap:** add `Casks/cassette.rb` to `MathieuDubart/homebrew-cassette`
+   (separate repo). The workflow rewrites its `version` and `sha256` on each tag.
+5. **Xcode Cloud:** create a tag-triggered (`v*`) iOS → TestFlight workflow in
+   App Store Connect. It picks up `ci_scripts/ci_pre_xcodebuild.sh` automatically.
+6. **Validate end-to-end** with a throwaway tag (e.g. `v0.0.1-rc1`), then delete
+   it (`git push --delete origin v0.0.1-rc1`).
+
+## Project facts the pipeline relies on
+
+- **Bundle ID:** `fr.mathieu-dubart.Cassette` · **Team ID:** `LK2358MPL8`
+- **macOS minimum:** 15.0 (Sequoia) — the cask should declare
+  `depends_on macos: ">= :sequoia"`.
+- **Toolchain:** the project requires **Xcode 27** (iOS 26 / macOS 26 SDK), so
+  the workflow runs on `macos-26` and pins `/Applications/Xcode_27.app`. Bump
+  both together when the toolchain moves; verify the exact Xcode path exists on
+  the chosen runner image.
+- **Versioning:** the `Cassette` target uses `apple-generic` versioning, which
+  `agvtool` (the Xcode Cloud script) requires. The macOS job sets the version via
+  `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` build-setting overrides, which
+  flow into the generated `Info.plist`.
+
+## Known things to check on the first run
+
+- The Widgets extension is **iOS-only** (`SUPPORTED_PLATFORMS` excludes macOS).
+  The macOS archive should skip it; if the macOS app is configured to embed it,
+  the archive step will fail and the embed must be made platform-conditional.
+- `create-dmg` cosmetics (icon coordinates, window size) assume a standard
+  drag-to-Applications layout; adjust in `release.yml` if the volume looks off.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -70,10 +70,12 @@ certificate, key, or password is stored in this repo.
 - **Bundle ID:** `fr.mathieu-dubart.Cassette` · **Team ID:** `LK2358MPL8`
 - **macOS minimum:** 15.0 (Sequoia) — the cask should declare
   `depends_on macos: ">= :sequoia"`.
-- **Toolchain:** the project requires **Xcode 27** (iOS 26 / macOS 26 SDK), so
-  the workflow runs on `macos-26` and pins `/Applications/Xcode_27.app`. Bump
-  both together when the toolchain moves; verify the exact Xcode path exists on
-  the chosen runner image.
+- **Toolchain:** the workflow runs on `macos-26` and selects the newest stable
+  Xcode via `maxim-lobanov/setup-xcode@v1` (`latest-stable`). The project is
+  authored with Xcode 27, a 2026 beta not yet on hosted runners. If it fails to
+  compile on the runner's GA Xcode because of a beta-only API, move to a
+  self-hosted runner with Xcode 27 — App Store submission requires a GA Xcode
+  anyway, so a beta-only dependency is a launch blocker to resolve regardless.
 - **Versioning:** the `Cassette` target uses `apple-generic` versioning, which
   `agvtool` (the Xcode Cloud script) requires. The macOS job sets the version via
   `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` build-setting overrides, which


### PR DESCRIPTION
## Summary

Adds tag-driven release automation. Pushing a `v*` tag fans out to two channels:
**Xcode Cloud** builds iOS and uploads to **TestFlight**, while **GitHub Actions**
(`.github/workflows/release.yml`) archives + Developer ID-signs the macOS app,
notarizes and staples it, packages a `.dmg`, publishes a **GitHub Release**, and
bumps the **Homebrew cask** in the tap. Full detail in
[`docs/RELEASE.md`](docs/RELEASE.md).

## Before the first tag (human-only, not done in CI)

- [ ] Create a **Developer ID Application** certificate; export it **with its
      private key** as `.p12`.
- [ ] Create an **App Store Connect API key** (`.p8`) for notarization.
- [ ] Add the **7 GitHub secrets** (see `docs/RELEASE.md`): cert `.p12` base64 +
      password, keychain password, ASC key `.p8` base64 + key id + issuer id, and
      the Homebrew tap token.
- [ ] Add `Casks/cassette.rb` to the **`homebrew-cassette`** tap with
      `depends_on macos: ">= :sequoia"` and an interpolated `#{version}` download `url`.
- [ ] Set up the **Xcode Cloud** `v*`-triggered iOS → TestFlight workflow.

## ⚠️ Dry-run before any real tag

**Once the secrets are set and this PR is merged, trigger `release.yml` via
`workflow_dispatch` first.** It builds + notarizes but does **not** publish a
Release or bump the cask (both guarded by `github.ref_type == 'tag'`). Confirm
that run is green before pushing any tag — this is where it surfaces whether the
project compiles on the runner's GA Xcode (26.x) or genuinely needs the beta
Xcode 27 toolchain.
